### PR TITLE
include_once change

### DIFF
--- a/sass/SassParser.php
+++ b/sass/SassParser.php
@@ -295,7 +295,7 @@ class SassParser {
 		
 		if (!empty($options['extensions'])) {
 			foreach ($options['extensions'] as $extension=>$extOptions) {
-				include dirname(__FILE__).DIRECTORY_SEPARATOR.'extensions'.DIRECTORY_SEPARATOR.$extension.DIRECTORY_SEPARATOR.'config.php';
+				include_once dirname(__FILE__).DIRECTORY_SEPARATOR.'extensions'.DIRECTORY_SEPARATOR.$extension.DIRECTORY_SEPARATOR.'config.php';
 				$configClass = 'SassExtentions'.$extension.'Config';
 				$config = new $configClass;
 				$config->config($extOptions);


### PR DESCRIPTION
Small change to avoid files being included multiple times - causes fatal PHP errors if they do.
