### PR TITLE
Bug in SassScriptLexer.php in PHP 7: substr() now returns empty string instead of false.

### DIFF
--- a/sass/script/SassScriptLexer.php
+++ b/sass/script/SassScriptLexer.php
@@ -49,7 +49,7 @@ class SassScriptLexer {
 	 */
 	public function lex($string, $context) {
 		$tokens = array();
-		while ($string !== false) {
+		while ($string != false) {
 			if (($match = $this->isWhitespace($string)) !== false) {
 				$tokens[] = null;
 			}


### PR DESCRIPTION
This file contains a loop checking if `$string !== false`. Because of this subtle change in PHP 7, the loop while statement evaluates as `"" !== false` which always returns true. The loop continues forever until PHP runs out of memory.

The simple fix is to replace the exact type check of `!==` with simply `!=`. Then when `substr()` returns an empty string, the comparison returns false and the loop breaks at the proper time.